### PR TITLE
add whitespace and +- support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ This interpreter is used by students in Cornell CS 3410 (starting Fall 2024) to 
 
 # TODOs
 
--   Add suppport for whitespace in the middle of arguments.
--   Add support for + in arguments, so that label offsets work.
+-   ~~Add suppport for whitespace in the middle of arguments.~~
+-   ~~Add support for + in arguments, so that label offsets work.~~
 -   Forward and backward support in labels.
 -   Add mul extension support.
 -   Better error-handling system for code (we have a lot of debug info generated but we never give it to the user).

--- a/packages/riscv-parser/src/lib_macro.ts
+++ b/packages/riscv-parser/src/lib_macro.ts
@@ -146,9 +146,22 @@ export const immediate_or_label = (
     // 12f, 12 instructions forward (pc = pc + 12 * 4)
     // Also add +, - offsets, so label + 12, or label - 10...
     if (imm_label === undefined) return undefined;
+    imm_label = imm_label.replaceAll(' ', '');
+    let added_offset = 0n;
+    const [label_str, sign, offset] = imm_label.split(/(\+|\-)/);
+    if (label_str !== undefined && sign !== undefined && offset !== undefined) {
+        added_offset = immediate(offset, 0n, 2n ** 64n - 1n) ?? 0n;
+        if (sign === '-') {
+            added_offset *= -1n;
+        }
+        imm_label = label_str;
+    }
+    if (added_offset % 4n !== 0n) {
+        return undefined;
+    }
     const label = label_table.get(imm_label);
     if (label !== undefined) {
-        return (BigInt(label) - 1n) * 4n;
+        return (BigInt(label) - 1n) * 4n + added_offset;
     }
     const imm = immediate(imm_label, min, max);
     if ((imm ?? 0n) % 4n !== 0n) {
@@ -163,7 +176,7 @@ export const imm_register = (
     max: bigint
 ): [bigint, number] | undefined => {
     if (imm_register === undefined) return undefined;
-    const [left, ...right] = imm_register.split('(');
+    const [left, ...right] = imm_register.replaceAll(' ', '').split('(');
     if (left === undefined || right.length !== 1) {
         return undefined;
     }

--- a/packages/riscv-parser/src/parser.test.ts
+++ b/packages/riscv-parser/src/parser.test.ts
@@ -88,14 +88,14 @@ test('Detects invalid lines', () => {
         parse_file(`main:
     add x1, x2, x3
     invalid_instruction # This should work fine, the parser doesn't know which macros exist.
-    sub x4 x5 x6 # Missing commas
+    !skibidi sigma rizz
   `)
     ).toStrictEqual([
         {
             message: `** (CompileError) **
 Irreducable expression @ line 4!
-Expression: sub x4 x5 x6 # Missing commas
-Normalized as: sub x4 x5 x6
+Expression: !skibidi sigma rizz
+Normalized as: !skibidi sigma rizz
 Is not empty but does not match label_expr | macro_expr`,
             line: 4,
         },

--- a/packages/riscv-parser/src/parser.ts
+++ b/packages/riscv-parser/src/parser.ts
@@ -13,7 +13,7 @@ export type riscv_ir = {
 
 // Thrown when a line does not contain one valid statement.
 // A valid line is defined as follows:
-// named_literal = a-z, A-Z, ., 0-9, _ (note no commas in named_literals, can't start with digit)
+// named_literal = a-z, A-Z, ., 0-9, _, +,- (note no commas in named_literals, can't start with digit)
 // argument = [preceeding_spaces][named_literal symbols as well as open and close parens no spaces in the middle, may start with digit][ending_spaces]
 // label = named_literal:
 // macro_expr = named_literal[at least one space][zero or more arguments separated by commas]
@@ -43,7 +43,7 @@ export const parse_file = (source: string): riscv_ir | compile_error[] => {
         !((normalized.at(0) ?? '0') >= '0' && (normalized.at(0) ?? '0') <= '9');
     const instr_pred = ({ normalized }: { normalized: string }) =>
         // Sus half GPT regex...
-        /^[a-zA-Z_][a-zA-Z0-9_.]*(\s+((\s*[0-9a-zA-Z_.()-]+\s*)(,\s*[0-9a-zA-Z_.()-]+\s*)*)?)?$/.test(
+        /^[a-zA-Z_][a-zA-Z0-9_.]*(\s+((\s*[0-9a-zA-Z_.()+\s-]+\s*)(,\s*[0-9a-zA-Z_.()+\s-]+\s*)*)?)?$/.test(
             normalized
         );
     const invalid_lines = lines.filter(


### PR DESCRIPTION
skibidi

whitespace can now be put in the middle of arguments
you can use +- offsets like the beq example in A5 (if your offset goes to an instruction before 0 the program terminates gracefully, which is somewhat sus behavior)